### PR TITLE
Fix broken codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # A Counting Latch
 
 [![Golang](https://github.com/bobvawter/latch/actions/workflows/golang.yaml/badge.svg)](https://github.com/bobvawter/latch/actions/workflows/golang.yaml)
-[![codecov](https://codecov.io/github/bobvawter/latch/branch/main/graph/badge.svg?token=3lUp406eyx)](https://codecov.io/github/bobvawter/latch)
+[![codecov](https://codecov.io/gh/bobvawter/latch/branch/main/graph/badge.svg?token=3lUp406eyx)](https://codecov.io/gh/bobvawter/latch)
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/bobvawter/latch)](https://pkg.go.dev/github.com/bobvawter/latch)
 
 This package contains a notification-based, counter latch. This is


### PR DESCRIPTION
The URL changed from github to gh.